### PR TITLE
Fix tag search via The Archive

### DIFF
--- a/search_tags.py
+++ b/search_tags.py
@@ -16,7 +16,7 @@ else:
 if bool(tag_results):
     for tag, counter in list(tag_results.items()):
         items.setItem(
-            arg=tag, # we cannot yet send a hash character with `thearchive://match/{query}`
+            arg="#%s" % tag,
             subtitle="{0} Hit(s), (\u2318 Paste Into Frontmost Application)".format(counter),
             title=tag,
             valid=True,


### PR DESCRIPTION
Searching tags worked as a full-text search before. This was problematic, especially with short tag names like `ai`.

Adding the hash symbol to the search query works perfectly for me.

Considering the previous comment, there might have been an issue earlier. Maybe I am missing something.